### PR TITLE
Fix header to be more consistent with design standards

### DIFF
--- a/css/tooplate-gymso-style.css
+++ b/css/tooplate-gymso-style.css
@@ -303,13 +303,13 @@
 
   .navbar-brand {
     color: var(--white-color);
-    font-family: 'Sushi Sans', sans-serif;
+    font-family: 'Sushi-Sans', sans-serif;
     font-size: var(--h4-font-size);
     font-weight: var(--font-weight-bold);
     margin-top: auto;
     margin-bottom: auto;
     line-height: normal;
-    padding-top: 0;
+    padding: 0;
   }
 
   .nav-item .nav-link {


### PR DESCRIPTION
This updates the `font-family` to be the correctly declared font family & removes the bottom padding in addition to the top padding in the header, which vertically centers the header.

Closes #11.